### PR TITLE
Example adding unnecessary clones in the NOT gate

### DIFF
--- a/tfhe/src/boolean/engine/mod.rs
+++ b/tfhe/src/boolean/engine/mod.rs
@@ -227,7 +227,7 @@ impl BooleanEngine {
                 lwe_ciphertext_opposite_assign(&mut ct_res);
 
                 // Output the result:
-                Ciphertext::Encrypted(ct_res)
+                Ciphertext::Encrypted(ct_res).clone()
             }
         }
     }


### PR DESCRIPTION
Add `clone()` on the NOT gate result